### PR TITLE
Fix "undefined method arch for Chef::Resource::Package"

### DIFF
--- a/libraries/provider_rvm_installation.rb
+++ b/libraries/provider_rvm_installation.rb
@@ -74,7 +74,7 @@ class Chef
 
       def install_packages
         Array(new_resource.install_pkgs).map do |pkg|
-          r = Chef::Resource::Package.new(pkg, run_context)
+          r = build_resource(:package, pkg)
           r.run_action(:install)
           r
         end


### PR DESCRIPTION
This has started appearing in recent versions of chef-client. I'm not
entirely sure why, perhaps because use_inline_resources was applied to
the generic package resource.

The same adjustment may be required elsewhere but this is the only one
that I've seen blow up so far.